### PR TITLE
Update ai to check for game end condition on Resume

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -68,10 +68,10 @@ export default {
         this.foundSet = false;
 
         //have ai check each time it resumes if game should end; copied from board logic
-        if (isDev)  console.log(`ai sets found: ${this.findValidSets().length}`);
-        if (isDev)  console.log(`ai cards left: ${deck.stock.length}`);
-        if (this.findValidSets().length === 0 && deck.stock.length === 0) {
-            setTimeout(() => game.end(), game.delay['add-cards']);
+        let numValidSets = this.findValidSets().length
+        if (isDev)  console.log(`ai sets found: ${numValidSets}, cards left: ${deck.stock.length`);
+        if (numValidSets === 0 && deck.stock.length === 0) {
+            game.end();
             return;
         }
 

--- a/js/ai.js
+++ b/js/ai.js
@@ -67,7 +67,7 @@ export default {
         this.test = 0;
         this.foundSet = false;
 
-        //have ai check each time it resumes if game should end; copied from board logic
+        // have ai check each time it resumes if game should end; this logic used to be in board.js before card draw
         let numValidSets = this.findValidSets().length
         if (isDev)  console.log(`ai sets found: ${numValidSets}, cards left: ${deck.stock.length`);
         if (numValidSets === 0 && deck.stock.length === 0) {

--- a/js/ai.js
+++ b/js/ai.js
@@ -67,6 +67,14 @@ export default {
         this.test = 0;
         this.foundSet = false;
 
+        //have ai check each time it resumes if game should end; copied from board logic
+        if (isDev)  console.log(`ai sets found: ${this.findValidSets().length}`);
+        if (isDev)  console.log(`ai cards left: ${deck.stock.length}`);
+        if (this.findValidSets().length === 0 && deck.stock.length === 0) {
+            setTimeout(() => game.end(), game.delay['add-cards']);
+            return;
+        }
+
         // Launch bot
         setTimeout(() => {
             if (!game.waiting) this.solve();

--- a/js/board.js
+++ b/js/board.js
@@ -34,11 +34,6 @@ export default {
             // Increment points
             game.updatePoints(1, winner);
 
-            if (ai.findValidSets().length === 0 && deck.stock.length === 0) {
-                setTimeout(() => game.end(), game.delay['add-cards']);
-                return;
-            }
-
             setTimeout(() => {
                 $('main').removeClass('waiting');
 


### PR DESCRIPTION
Love this game!  Found an edge case while playing a lot where, since board.js checks for game end condition (no valid sets on the table, no cards left in deck) before it drew 3 cards, if the final draw left the board with no sets, the game could never end. Moving this check to the ai Resume function makes it check after cards are drawn instead, which should catch all instance instead of missing that 3% edge case, since the ai resumes at the start of each play.

I tested the change by speeding up the ai solve speed and animation speed and playing until I hit that state and confirming it ended the game now. You can tell it succeeded here because the bot has 23 sets: 81 cards - 12 on the table without any sets = 69 cards = 23 sets; this is where in the current version it would just be stuck since there were no sets and no cards to add now, but when it last checked there were 3 cards left.

<img width="960" alt="image" src="https://github.com/ashugeo/set-game/assets/23406931/1f58e97f-9c87-48a8-8523-e3f2b7ed4772">
